### PR TITLE
Fix several return key pressed

### DIFF
--- a/src/sui-autocompleted/index.jsx
+++ b/src/sui-autocompleted/index.jsx
@@ -29,9 +29,12 @@ const upDownHandler = function(event) {
 
 const enterHandler = function() {
   const suggest = this.props.suggests[this.state.active];
-  const value = suggest.literal || suggest.content;
-  this.setState({value});
-  this.handleSelect(suggest);
+  
+  if(suggest) {
+    const value = suggest.literal || suggest.content;
+    this.setState({value});
+    this.handleSelect(suggest);
+  }
 };
 
 export default class Autocompleted extends React.Component {


### PR DESCRIPTION
When you press ENTER key several times, the first one selects the suggestion option and the following make javascript fail every time ENTER key is pressed.

This pull request fixes this issue.
