### PR TITLE
Accept HTML content in list-item

### DIFF
--- a/src/sui-autocompleted/list-item.jsx
+++ b/src/sui-autocompleted/list-item.jsx
@@ -13,9 +13,9 @@ export default class ListItem extends React.Component {
     });
     return (
       <li
+        dangerouslySetInnerHTML={{__html: this.props.item.content}}
         className={classes}
         onClick={this.props.handleSelect.bind(null, this.props.item)}>
-          {this.props.item.content}
       </li>
     );
   }


### PR DESCRIPTION
@davecarter @carlosvillu 

We need to support HTML content in the list-items of the autocomplete.

Use case:

![image](https://cloud.githubusercontent.com/assets/1822138/15543877/e52b5634-2296-11e6-9d0e-da15f15b6277.png)
