### PR TITLE
Feature/add optional prop input focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The component exposes the following props:
 
 * handleFocus (Function): This function is called everytime user focus on the input.
 * selectFirstByDefault (Boolean): **Optional** It sets first position for the autocomplete default active option. Defaults to `true`.
+* focus (Boolean): **Optional** It trigger focus in the input. Defaults to `false`.
 
 and then you have to create containers which one setting that properties in the sui-autocompleted component. You can view an example of this kind of container in the [doc folder](https://github.com/scm-spain/sui-autocompleted/blob/master/docs/autocompleted-container.jsx).
 
@@ -62,7 +63,7 @@ An SuggestObject is a plain JS Object with these specials keys:
     'id': [Unique id for the suggestion],
     'value': [value to be passed to the handleSelect callback function]
     'content': [React Component] or [Text to be show in the UI]
-    'literal': [String] This key is REQUIRED only if you are using a ReactJS Component like a content. It is used to decide which text has to be put in the input text when this suggestion is selected, in other case content will be used,    
+    'literal': [String] This key is REQUIRED only if you are using a ReactJS Component like a content. It is used to decide which text has to be put in the input text when this suggestion is selected, in other case content will be used,
 }
 ```
 

--- a/src/sui-autocompleted/index.jsx
+++ b/src/sui-autocompleted/index.jsx
@@ -11,8 +11,9 @@ export default class Autocompleted extends Component {
   constructor (...args) {
     super(...args);
 
-    const { selectFirstByDefault, initialValue } = this.props;
+    const { selectFirstByDefault, initialValue, focus } = this.props;
 
+    this.input = null;
     this.defaultPosition = selectFirstByDefault ? 0 : -1;
     this.moveDown = this.moveDown.bind(this);
     this.moveUp = this.moveUp.bind(this);
@@ -23,11 +24,13 @@ export default class Autocompleted extends Component {
     this.handleClear = this.handleClear.bind(this);
     this.handleSelect = this.handleSelect.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.focusInput = this.focusInput.bind(this);
 
     this.state = {
       active: this.defaultPosition,
       value: initialValue,
-      showResultList: false
+      showResultList: false,
+      focus: focus
     };
   }
 
@@ -44,6 +47,24 @@ export default class Autocompleted extends Component {
     return active === this.defaultPosition
       ? active
       : active - DELTA_MOVE;
+  }
+
+  componentDidMount () {
+    if (this.state.focus) {
+      this.focusInput();
+    }
+  }
+
+  componentWillReceiveProps ({ focus }) {
+    if (this.state.focus !== focus) {
+      this.setState({ focus });
+    }
+  }
+
+  componentWillUpdate (nextProps, { focus }) {
+    if (focus) {
+      this.focusInput();
+    }
   }
 
   upDownHandler (event) {
@@ -73,6 +94,10 @@ export default class Autocompleted extends Component {
     });
   }
 
+  focusInput () {
+    this.input.focus();
+  }
+
   handleChange (event) {
     const value = event.target.value;
     this.setState({
@@ -88,7 +113,7 @@ export default class Autocompleted extends Component {
         value: null
       }
     });
-    this.refs.autocompletedInput.focus();
+    this.focusInput();
   }
 
   handleSelect (suggest) {
@@ -135,11 +160,10 @@ export default class Autocompleted extends Component {
   render () {
     const { placeholder, handleFocus, handleBlur } = this.props;
     const { value, showResultList } = this.state;
-
     return (
       <div className='sui-Autocompleted'>
         <input
-          ref='autocompletedInput'
+          ref={ node => { this.input = node; }}
           value={value}
           placeholder={placeholder}
           className='sui-Autocompleted-input'
@@ -168,10 +192,12 @@ Autocompleted.propTypes = {
   initialValue: PropTypes.string,
   placeholder: PropTypes.string,
   suggests: PropTypes.array.isRequired,
-  selectFirstByDefault: PropTypes.bool
+  selectFirstByDefault: PropTypes.bool,
+  focus: PropTypes.bool
 };
 
 Autocompleted.defaultProps = {
   initialValue: '',
-  selectFirstByDefault: true
+  selectFirstByDefault: true,
+  focus: false
 };

--- a/src/sui-autocompleted/results-list.jsx
+++ b/src/sui-autocompleted/results-list.jsx
@@ -7,7 +7,7 @@ export default function ResultsList (props) {
       {props.suggests.map((suggest, index) =>
         ( <ListItem
             {...props}
-            key={suggest.id}
+            key={suggest.id || index}
             item={suggest}
             isActive={index === props.active}/>
         )


### PR DESCRIPTION
Solving issues:
- Fix warning about missing keys in suggestions list https://github.com/SUI-Components/sui-autocompleted/issues/22
- Add a new optional prop to force input to focus https://github.com/SUI-Components/sui-autocompleted/issues/21
- Switch from ref strings to ref callbacks https://github.com/SUI-Components/sui-autocompleted/issues/17

This PR breaks public API
